### PR TITLE
Set the active temperature sensor via added virtual switch

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -2814,6 +2814,19 @@ export default class NestAccfactory {
               protobufElement.state.value.brightness = scaleValue(Number(value), 0, 100, 0, 10); // Scale to required level
             }
 
+            if (key === 'active_temperature_sensor' && typeof value === 'boolean') {
+              protobufElement.traitRequest.resourceId = this.#rawData[nest_google_uuid].value.associated_thermostat;
+              protobufElement.traitRequest.traitLabel = 'remote_comfort_sensing_settings';
+              protobufElement.state.type_url = 'type.nestlabs.com/nest.trait.hvac.RemoteComfortSensingSettingsTrait';
+              protobufElement.state.value = {
+                activeRcsSelection: {
+                  activeRcsSensor: {
+                    resourceId: nest_google_uuid,
+                  }
+                }
+              };
+            }
+
             if (protobufElement.traitRequest.traitLabel === '' || protobufElement.state.type_url === '') {
               this?.log?.debug && this.log.debug('Unknown Protobuf set key "%s" for device uuid "%s"', key, nest_google_uuid);
             }


### PR DESCRIPTION
👋 Thank you for making & publishing this project! I swapped over to this plugin from `homebridge-nest` a few months back and it's been working great

One of the useful features in the Nest app, that's been difficult to fully automate (in any plugin/project), is the ability to change the active temperature sensor. Sometimes there are unexpected sunny/cloudy days, or doors/windows get opened, etc. Nest's scheduling functionality is primitive and changing this manually is... well, manual! 

To that end - I've added the ability to select the active temperature sensor in my fork of `homebridge-nest-accfactory` & wanted to offer it back as a PR if you were interested

I didn't find a "perfect" way to represent this in HomeKit. This PR implements it by creating a switch for each temperature sensor registered by the plugin. When you flip one of those switches on - that will become the active sensor in Nest. The Nest API & protobuf response parsing (from the Thermostat object) will ensure that only one switch is active at a time. I can confirm it works great with a single thermostat. It **should** also work with N sensors * M thermostats, but I don't have a way to verify this

No pressure at all if you don't want this / would prefer to model it differently / etc. Just wanted to say thanks & share!

---

Example usage:

New switches
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/3519770d-cc04-4ad4-ace3-fe16df42e1da" />

Switch details
<img width="785" alt="image" src="https://github.com/user-attachments/assets/bd43e201-e2ec-4674-8ece-ec902ddc41f0" />

Home Assistant integration

```yaml
    # customization - link the sensor <-> new switch
    sensor.guest_room_temperature:
      active_temperature_sensor: switch.guest_room_active_temperature_sensor

    # template - decide "what sensor should be active" based on ~anything in my home
    - name: "[Climate] Desired temperature sensor"
      state: |
        {% set sensors = label_entities('Thermostat sensors') | expand | sort(attribute='state') | list %}
        {% set coolest = sensors | first %}
        {% set warmest = sensors | last %}

        {% set mode = states('climate.entryway') %}
        {% if mode == "heat_cool" %}
          {# Bias to keeping the house cool, unless it's too cold early in the morning #}
          {% set current_hour = now().hour %}
          {% if current_hour < 8 and coolest.state | float < state_attr('climate.entryway', 'target_temp_low') %}
            {% set mode = "heat" %}
          {% else %}
            {% set mode = "cool" %}
          {% endif %}
        {% endif %}

        {% if mode == "heat" %}
          {{ coolest.entity_id }}
        {% elif mode == "cool" %}
          {{ warmest.entity_id }}
        {% endif %}

  # automation - when I change "what should be active", flip the new switch added in this PR
  - alias: "[Climate] Set active temperature sensor"
    trigger:
      - platform: state
        entity_id:
          - sensor.climate_desired_temperature_sensor
    action:
      - action: switch.turn_on
        target:
          entity_id: "{{ state_attr(trigger.to_state.state, 'active_temperature_sensor') }}"
```