### PR TITLE
Add optional streaming switch and person motion sensor support to NestCamera

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Sample config.json entries below
             "serialNumber": "XXXXXXXX",
             "exclude": false
         },
+        {
             "serialNumber": "YYYYYYYY",
-            "hksv" : true
+            "hksv": true
         }
     ],
     "platform": "NestAccfactory"
@@ -135,7 +136,9 @@ The following options are available on a per-device level in the `config.json` `
 | localAccess        | Use direct access to supported camera(s) and doorbell(s) for video streaming and recording   | false          |    
 | motionCooldown     | Time in seconds between detected motion events                                               | 60             |
 | personCooldown     | Time in seconds between detected person events                                               | 120            |
-| serialNumber       | Device serial number to which these settings belong too                                      |                |
+| personSensor       | Create a separate motion sensor for person detection for supported camera(s) and doorbell(s) | false          |
+| serialNumber       | Device serial number to which these settings belong to                                       |                |
+| streamingSwitch    | Create a switch for supported camera(s) and doorbell(s) to turn streaming on/off             | false          |
 
 ## ffmpeg
 


### PR DESCRIPTION
This PR introduces two new features, addressing issues #219 and #220:
1.  A **Streaming Switch** to turn the camera on and off via the Nest/Google API.
2.  A separate **Person Motion Sensor** for person-specific automations.

I've paid close attention to our discussion and your design philosophy for a seamless, unobtrusive integration with Apple Home. For that reason, I have implemented both features as **completely optional and disabled by default**. For users who don't enable them, the plugin's behavior and exposed accessories remain exactly the same.

Here is a more detailed justification for why these features are valuable, non-redundant additions for pure Apple HomeKit users:

#### 1. The Streaming Switch: A Fundamental Privacy Feature

Regarding the Streaming Switch, I did some deeper research into your point about HKSV's modes, and it appears there's a crucial technical distinction between what HKSV's "Off" setting controls and what this switch accomplishes:

*   **What HKSV 'Off' Does:** It instructs the Apple Home Hub (Apple TV/HomePod) to **stop requesting and processing the video stream**. However, this command does not get passed through to the Nest camera itself. The camera remains active and continues to transmit its video feed to Google's servers based on its settings in the Nest/Google Home app.

*   **What This Streaming Switch Does:** It uses the Nest/Google API to send an explicit `streaming_enabled: false` command directly to the camera, telling it to **stop transmitting video to the cloud entirely**.

This makes the switch a fundamental **privacy feature**, not just an automation tool. It's the only way a user can be certain their indoor camera is truly "off" and not sending video to Google's servers. This aligns perfectly with the privacy-centric ethos of the Apple ecosystem and enables powerful privacy automations:
*   "When the first person arrives home, turn off the Indoor Camera."
*   "When my Security System is Disarmed, turn off all cameras."

#### 2. The Person Motion Sensor: Smarter Automations for All Users

Similarly, for the Person Sensor, you're right that HKSV offers excellent person detection. However, that functionality is contingent on a paid iCloud+ subscription.

This optional sensor provides a valuable, plugin-based alternative for users within the Apple ecosystem who may not have an iCloud+ plan but still want to create more intelligent automations and reduce notification fatigue. For example:
*   "When a *person* is detected on the Porch at night, turn on the outside lights."
*   "Send me a notification only if a *person* is detected, ignoring pets or swaying trees."

---

I've implemented these features carefully to minimize code changes and align with the existing structure. By making them opt-in, they enhance the plugin's capabilities for users who need them without compromising the simple, clean experience for everyone else.

Thank you for considering this contribution. I am happy to make any changes you see fit.