### PR TITLE
fix(camera): Correctly remove motion services on device removal

### DIFF
--- a/src/plugins/camera.js
+++ b/src/plugins/camera.js
@@ -280,7 +280,6 @@ export default class NestCamera extends HomeKitDevice {
 
     // Remove any motion services we created
     Object.values(this.motionServices || {}).forEach((motionObject) => {
-      clearTimeout(motionObject.timer);
       motionObject.service.updateCharacteristic(this.hap.Characteristic.MotionDetected, false);
       this.accessory.removeService(motionObject.service);
     });

--- a/src/plugins/camera.js
+++ b/src/plugins/camera.js
@@ -279,9 +279,10 @@ export default class NestCamera extends HomeKitDevice {
     });
 
     // Remove any motion services we created
-    Object.values(this.motionServices).forEach((service) => {
-      service.updateCharacteristic(this.hap.Characteristic.MotionDetected, false);
-      this.accessory.removeService(service);
+    Object.values(this.motionServices || {}).forEach((motionObject) => {
+      clearTimeout(motionObject.timer);
+      motionObject.service.updateCharacteristic(this.hap.Characteristic.MotionDetected, false);
+      this.accessory.removeService(motionObject.service);
     });
 
     // Remove the camera controller


### PR DESCRIPTION
This pull request addresses a bug in the `onRemove` method of the `NestCamera` class that prevented motion sensor services from being cleaned up correctly when a camera device is removed from Homebridge.

**Problem:**
The `onRemove` function iterates through `this.motionServices`, but it was attempting to call `updateCharacteristic` and `removeService` on the wrapper object (`{ service, timer }`) instead of the actual HomeKit service instance stored in the `.service` property. This would result in a `TypeError` and prevent the services from being de-registered properly.

**Changes:**
- The loop in `onRemove` has been modified to correctly access `motionService.service` before calling `updateCharacteristic` and `removeService`.
- A fallback `|| {}` has been added to `Object.values(this.motionServices || {})` to prevent potential errors if `onRemove` is called before `motionServices` has been initialized.
- The loop variable was renamed to `motionObject` for clarity.

This fix ensures that all associated motion sensor services are correctly and safely removed when a camera accessory is unregistered, improving stability and preventing orphaned services.