### PR TITLE
Fix WebRTC crash when HomeGraph home has no devices

### DIFF
--- a/src/webrtc.js
+++ b/src/webrtc.js
@@ -4,7 +4,7 @@
 // Handles connection and data from Google WebRTC systems
 // Currently a "work in progress"
 //
-// Code version 2025.11.22
+// Code version 2026.01.24
 // Mark Hulskamp
 'use strict';
 


### PR DESCRIPTION
Avoid calling Object.values() on undefined home.devices / otherThirdPartyId when mapping Nest DEVICE_* ids to Google Home Foyer ids.

I can confirm this fixes #298 for me and the stream is now visible without issues.